### PR TITLE
fix: per-project allow list display + RulesPayload alignment

### DIFF
--- a/MaestroRemote/AllowListView.swift
+++ b/MaestroRemote/AllowListView.swift
@@ -41,12 +41,13 @@ struct AllowListView: View {
 
     private var list: some View {
         List {
+            // グローバル allow list
             Section {
                 if rules?.allowedTools.isEmpty ?? true {
                     Text("No tools in allow list")
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(rules?.allowedTools.sorted() ?? [], id: \.self) { tool in
+                    ForEach(rules?.allowedTools ?? [], id: \.self) { tool in
                         HStack {
                             Text(toolEmoji(tool))
                             Text(tool)
@@ -55,16 +56,34 @@ struct AllowListView: View {
                         }
                     }
                     .onDelete { indexSet in
-                        let sorted = rules?.allowedTools.sorted() ?? []
+                        let list = rules?.allowedTools ?? []
                         for i in indexSet {
-                            Task { await removeTool(sorted[i]) }
+                            Task { await removeTool(list[i]) }
                         }
                     }
                 }
             } header: {
-                Text("Auto-approved tools")
+                Text("Global")
             } footer: {
-                Text("These tools are approved automatically without asking.")
+                Text("Applied to all projects unless overridden.")
+            }
+
+            // プロジェクト別 allow list（設定があるもののみ表示）
+            ForEach(rules?.registeredProjects.filter { $0.allowedTools != nil } ?? []) { project in
+                Section {
+                    ForEach(project.allowedTools ?? [], id: \.self) { tool in
+                        HStack {
+                            Text(toolEmoji(tool))
+                            Text(tool)
+                                .font(.system(.body, design: .monospaced))
+                            Spacer()
+                        }
+                    }
+                } header: {
+                    Text(project.displayName)
+                } footer: {
+                    Text("Overrides global list for this project.")
+                }
             }
         }
         .listStyle(.insetGrouped)

--- a/MaestroRemote/MaestroClient.swift
+++ b/MaestroRemote/MaestroClient.swift
@@ -236,12 +236,20 @@ class MaestroClient: ObservableObject {
     struct RulesPayload: Codable {
         let allowedTools: [String]
         let blockRules: [BlockRule]
+        let registeredProjects: [RegisteredProject]
 
         struct BlockRule: Identifiable, Codable {
             let id: String
             let toolName: String
             let pattern: String
             let note: String
+        }
+
+        struct RegisteredProject: Identifiable, Codable {
+            let id: String
+            let displayName: String
+            let allowedTools: [String]?   // nil = グローバルにフォールバック
+            let blockRules: [BlockRule]?  // nil = グローバルにフォールバック
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Allow List がプロジェクト別設定を表示しない問題**: `RulesPayload.RegisteredProject` に `allowedTools` / `blockRules` フィールドを追加し、`AllowListView` で「Global」セクション＋プロジェクト別セクションに分けて表示するよう変更。

## Changes

- `MaestroClient.swift`: `RulesPayload.RegisteredProject` に `allowedTools: [String]?`, `blockRules: [BlockRule]?` を追加
- `AllowListView.swift`: グローバル allow list を "Global" セクション、プロジェクト別 allow list を各プロジェクト名セクションで表示

## Test plan

- [ ] Allow List でグローバルリストが "Global" セクションに表示される
- [ ] プロジェクト別 allow list が設定されているプロジェクトは個別セクションで表示される
- [ ] プロジェクト別設定がないプロジェクトはリストに出ない（グローバルにフォールバック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)